### PR TITLE
Fix notification service parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,16 +120,6 @@ func (s *slackOutput) notificationServiceRoutes(fields map[string]interface{}) [
 		return []decode.NotificationRoute{}
 	}
 
-	// Convert Data to a proper object
-	if alert.Data != nil && alert.Data != "" {
-		var data map[string]interface{}
-		err = json.Unmarshal([]byte(alert.Data.(string)), &data)
-		// If there's an error, just continue and skip this update
-		if err == nil {
-			alert.Data = data
-		}
-	}
-
 	alertJson, err := json.Marshal(alert)
 	if err != nil {
 		return []decode.NotificationRoute{}

--- a/main_test.go
+++ b/main_test.go
@@ -434,7 +434,7 @@ func TestSendBatchInternalRateLimit(t *testing.T) {
 	// 3 secs have passed
 	delta := messageTimestamps[len(messageTimestamps)-1].Sub(messageTimestamps[0])
 	assert.True(t,
-		delta+time.Millisecond >= time.Duration(3*time.Second), // Adding fuzz factor
+		delta+100*time.Millisecond >= time.Duration(3*time.Second), // Adding fuzz factor
 		"Elapsed time '%v' should be more than 3 seconds", delta)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -70,7 +70,7 @@ func TestNotificationServiceRoutes(t *testing.T) {
 		"app_id":                  "app__id",
 		"district_id":             "district__id",
 		"value":                   "314159",
-		"data":                    `{"some":"data","with":"meaning"}`,
+		"data":                    map[string]interface{}{"some": "data", "with": "meaning"},
 	}
 
 	routes := sender.globalRoutes(input)


### PR DESCRIPTION
This was causing panics in dev: https://dev-infra--haproxy-logs.int.clever.com/_plugin/kibana/#/discover?_a=(columns:!(rawlog),filters:!((meta:(disabled:!f,index:%5Blogs-%5DYYYY-MM-DD,key:container_task,negate:!f,value:'3864af9a-47b9-44c6-b868-789f0a76fbe7'),query:(match:(container_task:(query:'3864af9a-47b9-44c6-b868-789f0a76fbe7',type:phrase)))),(meta:(disabled:!f,index:%5Blogs-%5DYYYY-MM-DD,key:rawlog,negate:!t,value:'Aug%2025,%202017%2012:01:24%20AM%20com.amazonaws.services.kinesis.multilang.DrainChildSTDERRTask%20handleLine'),query:(match:(rawlog:(query:'Aug%2025,%202017%2012:01:24%20AM%20com.amazonaws.services.kinesis.multilang.DrainChildSTDERRTask%20handleLine',type:phrase))))),index:%5Blogs-%5DYYYY-MM-DD,interval:auto,query:(query_string:(analyze_wildcard:!t,lowercase_expanded_terms:!f,query:'container_app:kinesis-notifications-consumer%20AND%20NOT%20%22SEVERE:%22%20AND%20%22panic%22')),sort:!(timestamp,desc))&_g=(refreshInterval:(display:Off,section:0,value:0),time:(from:now-1h,mode:relative,to:now))

cc @bstein-clever 