### PR TITLE
fix unknown errors; update amazon-kinesis-client-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 41e70f2a75c4de557e079d23d25bb2bd3952b8ef9f58de0ec63dda6e3ff79cf5
-updated: 2017-09-11T20:14:36.354732448Z
+updated: 2017-09-13T19:25:59.003289025Z
 imports:
 - name: github.com/Clever/amazon-kinesis-client-go
-  version: 7f39898b70c287c2ecdfa9f8d6fec28ed48485e0
+  version: 32d4d33f00a3672a8cc76af1361ff982ed62d1ad
   subpackages:
   - batchconsumer
   - batchconsumer/stats

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -2,10 +2,10 @@ routes:
   unknown-error-alerts:
     matchers:
       title: ["stats"]
+      unknown-error: [ "*" ]
     output:
       type: "alerts"
       series: "kinesis-consumer.notifications.unknown-error"
       dimensions: [ ]
-      # 0 for ongoing; 1 for failed; -1 for cancelled
       value_field: "unknown-error" 
       stat_type: "counter"


### PR DESCRIPTION
only send when `unknown-error` is set. 

also wait for https://github.com/Clever/amazon-kinesis-client-go/pull/16 which makes `unknown-error` to always be set so that we have `0`'s in signalfx