### PR TITLE
bump cpu significantly

### DIFF
--- a/launch/kinesis-notifications-consumer.yml
+++ b/launch/kinesis-notifications-consumer.yml
@@ -13,11 +13,11 @@ env:
   - READ_RATE_LIMIT
   - THROTTLE_THRESHOLD
 resources:
-  cpu: 0.1
+  cpu: 0.5
   soft_mem_limit: 1
   max_mem: 2
 shepherds:
-- "xavi.ramirez@clever.com"
+- "rafael.garcia@clever.com"
 expose: []
 team: "eng-infra"
 aws:


### PR DESCRIPTION
before rollback, saw a big cpu spike when deploying the previous PR to bump the KCL version. Going to give this a big CPU bump for now to rule out CPU starvation as a source of problems