### PR TITLE
revert it all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ $(eval $(call golang-version-check,1.10))
 
 TMP_DIR := /tmp/kinesis-notifications-consumer-jars
 JAR_DIR := ./jars
-KCL_VERSION := 2.1.3
+KCL_VERSION := 1.8.10
 
 define POM_XML_FOR_GETTING_DEPENDENT_JARS
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -21,8 +21,8 @@ define POM_XML_FOR_GETTING_DEPENDENT_JARS
   <version>1.0-SNAPSHOT</version>
   <dependencies>
     <dependency>
-      <groupId>software.amazon.kinesis</groupId>
-      <artifactId>amazon-kinesis-client-multilang</artifactId>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>amazon-kinesis-client</artifactId>
       <version>$(KCL_VERSION)</version>
     </dependency>
   </dependencies>

--- a/consumer.properties.template
+++ b/consumer.properties.template
@@ -45,7 +45,7 @@ regionName = <REGION_NAME>
 #shardSyncIntervalMillis = 60000
 
 # Max records to fetch from Kinesis in a single GetRecords call.
-maxRecords = 10000
+#maxRecords = 10000
 
 # Idle time between record reads in milliseconds.
 #idleTimeBetweenReadsInMillis = 1000

--- a/launch/kinesis-notifications-consumer.yml
+++ b/launch/kinesis-notifications-consumer.yml
@@ -13,7 +13,7 @@ env:
   - READ_RATE_LIMIT
   - THROTTLE_THRESHOLD
 resources:
-  cpu: 0.5
+  cpu: 0.2
   soft_mem_limit: 1
   max_mem: 2
 shepherds:

--- a/run_kcl.sh
+++ b/run_kcl.sh
@@ -19,4 +19,4 @@ if [ "$AWS_SHARED_CREDENTIALS_FILE" != "" ] ; then
     export AWS_CREDENTIAL_PROFILES_FILE=$AWS_SHARED_CREDENTIALS_FILE
 fi
 command -v java >/dev/null 2>&1 || { echo >&2 "Java not installed. Install java!"; exit 1; }
-exec java -cp "jars/*" software.amazon.kinesis.multilang.MultiLangDaemon consumer.properties
+exec java -cp "jars/*"  com.amazonaws.services.kinesis.multilang.MultiLangDaemon consumer.properties


### PR DESCRIPTION
was not able to successfully upgrade to version 2.X of the KCL

the upgrade caused a subset of consumers to generate a ton of error messages of the form 

```
2019-03-27 17:59:05,215 [ShardRecordProcessor-0008] ERROR s.a.k.multilang.MultiLangProtocol [NONE] - Was asked to checkpoint at 49594088390872412655227569321412088042541308187645062258 but no checkpointer was provided for shard shardId-000000000711
```

which caused individual ECS hosts to fall behind. 